### PR TITLE
Updated to 0.25 and let GCC_10 to be used for the build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # *****************************************************************
-# (C) Copyright IBM Corp. 2021. All Rights Reserved.
+# (C) Copyright IBM Corp. 2021, 2022. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,20 @@
 # *****************************************************************
 set -vex
 
+PATH_VAR="$PATH"
+if [[ $ppc_arch == "p10" ]]
+then
+    if [[ -z "${GCC_10_HOME}" ]];
+    then
+        echo "Please set GCC_10_HOME to the install path of gcc-toolset-10"
+        exit 1
+    else
+        export PATH=${GCC_10_HOME}/bin/:$PATH
+    fi
+    GCC_USED=`which gcc`
+    echo "GCC being used is ${GCC_USED}"
+fi
+
 #Clean up old bazel cache to avoid problems building TF
 bazel clean --expunge
 bazel shutdown
@@ -37,3 +51,6 @@ python -m pip install dist/*.whl
 
 bazel clean --expunge
 bazel shutdown
+
+#Restore $PATH variable
+export PATH=$PATH_VAR

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_version = "0.24.0" %}
+{% set build_version = "0.25.0" %}
 
 package:
   name: tensorflow-io-gcs-filesystem
@@ -16,6 +16,8 @@ source:
 build:
   number: 1
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
+  script_env:        # [ppc_arch == "p10"]
+    - GCC_10_HOME    # [ppc_arch == "p10"]
 
 requirements:
   build:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

TF IO has a known issue with its dependency named `boringssl` not being compatible with GCC 11. 
Commits in boringssl that enables GCC 11 support -
https://github.com/google/boringssl/commit/597ffef971dd980b7de5e97a0c9b7ca26eec94bc
https://github.com/google/boringssl/commit/92c6fbfc4c44dc8462d260d836020d2b793e7804
Unfortunately picking up these commits on top of the boringssl version used in TF IO causes other issues. Hence, for Open-CE 1.6.1, we will continue using GCC 10 for TF IO  and revisit this in next release.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
