### PR TITLE
Fixed issue of cuda packages being pulled with cpu variant

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - 0303-Fix-jpeg-build-in-Tensorflow.patch     #[ppc64le]
 
 build:
-  number: 2
+  number: 3
   string: {{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
   string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 
@@ -39,6 +39,8 @@ outputs:
         - python {{ python }}
         - numpy {{ numpy }}
         - tensorflow-base {{ tensorflow }}
+        - _tensorflow_select 1.0          #[build_type == 'cpu']
+        - _tensorflow_select 2.0          #[build_type == 'cuda']
         - keras {{ keras }}
         - tensorflow-estimator {{ tensorflow }}
         - tensorboard {{ tensorboard }}
@@ -46,6 +48,8 @@ outputs:
         - python {{ python }}
         - numpy {{ numpy }}
         - tensorflow-base {{ tensorflow }}
+        - _tensorflow_select 1.0          #[build_type == 'cpu']
+        - _tensorflow_select 2.0          #[build_type == 'cuda']
         - keras {{ keras }}
         - tensorflow-estimator {{ tensorflow }}
         - tensorboard {{ tensorboard }}
@@ -63,6 +67,8 @@ outputs:
         - python {{ python }}
         - numpy {{ numpy }}
         - tensorflow-base {{ tensorflow }}
+        - _tensorflow_select 1.0          #[build_type == 'cpu']
+        - _tensorflow_select 2.0          #[build_type == 'cuda']
         - keras {{ keras }}
         - tensorflow-estimator {{ tensorflow }}
         - tensorboard {{ tensorboard }}
@@ -70,6 +76,8 @@ outputs:
         - python {{ python }}
         - numpy {{ numpy }}
         - tensorflow-base {{ tensorflow }}
+        - _tensorflow_select 1.0          #[build_type == 'cpu']
+        - _tensorflow_select 2.0          #[build_type == 'cuda']
         - keras {{ keras }}
         - tensorflow-estimator {{ tensorflow }}
         - tensorboard {{ tensorboard }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
Even at build time, I noticed cpu build of TF IO is using cuda variant of TF base.

This issue was also present in our 1.9 RCs and may be in 1.8.0 too. In Open-CE 1.7.7 it works as expected which means the problem started occuring since we included TF IO along with TF IO GCS Filesystem and added a few more deps like keras. I'm still unclear about the exact cause, but this should fix the cpu/cuda confusion even at build time.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
