### PR TITLE
Fixed failure on sys_siglist with strsignal

### DIFF
--- a/buildscripts/set_tf_io_bazelrc.sh
+++ b/buildscripts/set_tf_io_bazelrc.sh
@@ -60,6 +60,7 @@ ${CPU_TUNE_HOST_OPTION}
 build --copt="-fvisibility=hidden"
 build --copt="-D_GLIBCXX_USE_CXX11_ABI=1"
 build --copt="-DEIGEN_MAX_ALIGN_BYTES=64"
+build --copt="-Wno-maybe-uninitialized"
 build --action_env TF_HEADER_DIR="$PREFIX/lib/python${PY_VER}/site-packages/tensorflow/include"
 build --action_env TF_SHARED_LIBRARY_DIR="$PREFIX/lib/python${PY_VER}/site-packages/tensorflow"
 build --action_env TF_SHARED_LIBRARY_NAME="libtensorflow_framework.so.2"

--- a/recipe/0001-failure-on-sys_siglist.patch
+++ b/recipe/0001-failure-on-sys_siglist.patch
@@ -1,0 +1,92 @@
+From 618b8d2e2d781e18e0f0b3ed4bc86b294e937590 Mon Sep 17 00:00:00 2001
+From: ArchanaShinde1 <archana.shinde2504@gmail.com>
+Date: Thu, 1 Feb 2024 08:45:10 +0000
+Subject: [PATCH] failure on sys_siglist
+
+---
+ WORKSPACE                                     |  1 +
+ ...cation-of-sys_siglist-with-strsignal.patch | 60 +++++++++++++++++++
+ 2 files changed, 61 insertions(+)
+ create mode 100644 third_party/0001-fix-deprecation-of-sys_siglist-with-strsignal.patch
+
+diff --git a/WORKSPACE b/WORKSPACE
+index ca83cb17..f2652c2b 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -475,6 +475,7 @@ http_archive(
+     patch_args = ["-p1"],
+     patches = [
+         "//third_party:libapr1.patch",
++        "//third_party:0001-fix-deprecation-of-sys_siglist-with-strsignal.patch"
+     ],
+     sha256 = "096968a363b2374f7450a3c65f3cc0b50561204a8da7bc03a2c39e080febd6e1",
+     strip_prefix = "apr-1.6.5",
+diff --git a/third_party/0001-fix-deprecation-of-sys_siglist-with-strsignal.patch b/third_party/0001-fix-deprecation-of-sys_siglist-with-strsignal.patch
+new file mode 100644
+index 00000000..eb40c066
+--- /dev/null
++++ b/third_party/0001-fix-deprecation-of-sys_siglist-with-strsignal.patch
+@@ -0,0 +1,60 @@
++From 3faeb8046a88e9915d49a78d407bd1ab120ad078 Mon Sep 17 00:00:00 2001
++From: ArchanaShinde1 <archana.shinde2504@gmail.com>
++Date: Thu, 1 Feb 2024 07:24:59 +0000
++Subject: [PATCH] fix deprecation of sys_siglist with strsignal
++
++---
++ configure.in              | 4 ++--
++ threadproc/unix/signals.c | 6 +++---
++ 2 files changed, 5 insertions(+), 5 deletions(-)
++
++diff --git a/configure.in b/configure.in
++index be6777f7b..7d30cb516 100644
++--- a/configure.in
+++++ b/configure.in
++@@ -1436,7 +1436,7 @@ AC_ARG_WITH(sendfile, [  --with-sendfile         Override decision to use sendfi
++ AC_SUBST(sendfile)
++ 
++ AC_CHECK_FUNCS(sigaction, [ have_sigaction="1" ], [ have_sigaction="0" ]) 
++-AC_DECL_SYS_SIGLIST
+++AC_STRSIGNAL
++ 
++ AC_CHECK_FUNCS(fork, [ fork="1" ], [ fork="0" ])
++ APR_CHECK_INET_ADDR
++@@ -1584,7 +1584,7 @@ AC_SUBST(stringh)
++ AC_SUBST(stringsh)
++ AC_SUBST(sys_ioctlh)
++ AC_SUBST(sys_sendfileh)
++-AC_SUBST(sys_signalh)
+++AC_SUBST(strsignalh)
++ AC_SUBST(sys_socketh)
++ AC_SUBST(sys_sockioh)
++ AC_SUBST(sys_typesh)
++diff --git a/threadproc/unix/signals.c b/threadproc/unix/signals.c
++index 57a31af97..26295a5d7 100644
++--- a/threadproc/unix/signals.c
+++++ b/threadproc/unix/signals.c
++@@ -109,17 +109,17 @@ APR_DECLARE(apr_sigfunc_t *) apr_signal(int signo, apr_sigfunc_t * func)
++ 
++ /* AC_DECL_SYS_SIGLIST defines either of these symbols depending
++  * on the version of autoconf used. */
++-#if defined(SYS_SIGLIST_DECLARED) || HAVE_DECL_SYS_SIGLIST
+++#if defined(STRSIGNAL_DECLARED) || HAVE_STRSIGNAL
++ 
++ void apr_signal_init(apr_pool_t *pglobal)
++ {
++ }
++ const char *apr_signal_description_get(int signum)
++ {
++-    return (signum >= 0) ? sys_siglist[signum] : "unknown signal (number)";
+++    return (signum >= 0) ? strsignal(signum) : "unknown signal (number)";
++ }
++ 
++-#else /* !(SYS_SIGLIST_DECLARED || HAVE_DECL_SYS_SIGLIST) */
+++#else /* !(STRSIGNAL_DECLARED || HAVE_STRSIGNAL) */
++ 
++ /* we need to roll our own signal description stuff */
++ 
++-- 
++2.40.1
++
+-- 
+2.40.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ source:
     - 0301-Updated-protobuf-to-4.21.patch
     - 0302-Fix-libwebp-linking-errors.patch
     - 0303-Fix-jpeg-build-in-Tensorflow.patch     #[ppc64le]
+    - 0001-failure-on-sys_siglist.patch    #[ppc_arch == 'p10']
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     - 0001-failure-on-sys_siglist.patch    #[ppc_arch == 'p10']
 
 build:
-  number: 3
+  number: 4
   string: {{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
   string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
 Referred to fix this issue:
 https://github.com/greenbone/gvmd/pull/1280/files
 https://github.com/coelckers/prboom-plus/pull/130/files
 
From the release notes of glibc 2.32, https://sourceware.org/pipermail/libc-announce/2020/000029.html

The deprecated arrays sys_siglist, _sys_siglist, and sys_sigabbrev
  are no longer available to newly linked binaries, and their declarations
  have been removed from <string.h>.  They are exported solely as
  compatibility symbols to support old binaries.  All programs should use
  strsignal instead.
  
 


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
