### PR TITLE
Renamed bazel-toolchain to toolchains_llvm

### DIFF
--- a/recipe/0302-Fixed-Rename-from-bazel-toolchain-to-toolchains_llvm.patch
+++ b/recipe/0302-Fixed-Rename-from-bazel-toolchain-to-toolchains_llvm.patch
@@ -1,0 +1,31 @@
+From aa7407d86753d34da0b5bc835b2aae828c078c67 Mon Sep 17 00:00:00 2001
+From: ArchanaShinde1 <archana.shinde2504@gmail.com>
+Date: Mon, 19 Feb 2024 16:41:40 +0000
+Subject: [PATCH] update checksum to fix failure on toolchains_llvm
+
+---
+ WORKSPACE | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index c60b5d8f..80e11073 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -880,11 +880,11 @@ http_archive(
+ # Needed for llvm_toolchain and Golang
+ http_archive(
+     name = "com_grail_bazel_toolchain",
+-    sha256 = "9e6065ded4b7453143e1586d6819729a63cd233114b72bf85ff3435367b02c90",
+-    strip_prefix = "bazel-toolchain-edd07e96a2ecaa131af9234d6582875d980c0ac7",
++    sha256 = "4b7999c1fa2c3117bb21651e3c155b152e44ae67b2c311214883d4707dbe183f",
++    strip_prefix = "toolchains_llvm-edd07e96a2ecaa131af9234d6582875d980c0ac7",
+     urls = [
+         "https://storage.googleapis.com/mirror.tensorflow.org/github.com/grailbio/bazel-toolchain/archive/edd07e96a2ecaa131af9234d6582875d980c0ac7.tar.gz",
+-        "https://github.com/grailbio/bazel-toolchain/archive/edd07e96a2ecaa131af9234d6582875d980c0ac7.tar.gz",
++        "https://github.com/bazel-contrib/toolchains_llvm/archive/edd07e96a2ecaa131af9234d6582875d980c0ac7.tar.gz",
+     ],
+ )
+ 
+-- 
+2.40.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - 0302-Fixed-Rename-from-bazel-toolchain-to-toolchains_llvm.patch
 
 build:
-  number: 1
+  number: 2
   string: {{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
   string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
     - 0108-Fixed-upb.patch
     - 0109-Add-include-path-for-rpc-headers-from-libtirpc-devel.patch   #[ppc_arch == 'p10']
     - 0301-Updated-protobuf-to-4.21.patch
+    - 0302-Fixed-Rename-from-bazel-toolchain-to-toolchains_llvm.patch
 
 build:
   number: 1


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
As part of the transfer to the bazel-contrib org, the repo has been renamed to
`toolchains_llvm`. This has affected the dynamically generated source archives
which now have a different tree prefix, and different shasum.

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
